### PR TITLE
Revert "`AUTOBUILD` `README.md` & fetch fork"

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,3 @@ yarn dev
 ```bash
 yarn autobuild
 ```
-## For Developers
-During rapid development, to fetch a fresh copy of the repository, use:
-```bash
-bash scripts/AUTOBUILD.sh clean  # or  bash scripts/AUTOBUILD.sh clean [github username of the fork]
-```
-To find out full functionality, use;
-```bash
-bash scripts/AUTOBUILD.sh --help  
-```

--- a/README.md
+++ b/README.md
@@ -165,8 +165,24 @@ yarn load-wasm:system
 yarn dev
 ```
 
-
 # Using Autobuild
+
 ```bash
-yarn autobuild
+yarn autobuild deploy
+```
+
+This will automatically build the project and deploy it to the local dfx instance. It will also generate the candid and typescript bindings. It will also load the wasm module to the system canister. Finally, it will start the development server.
+
+## For Developers
+
+During rapid development, to fetch a fresh copy of the repository, use:
+
+```bash
+yarn autobuild clean  # or  yarn autobuild clean [github username of the fork]
+```
+
+To find out full functionality, use;
+
+```bash
+yarn autobuild --help
 ```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dfinity"
   ],
   "scripts": {
-    "autobuild":"bash ./scripts/AUTOBUILD.sh deploy",
+    "autobuild": "bash ./scripts/AUTOBUILD.sh",
     "start": "npx serve@latest out",
     "dfx:start": "bash ./scripts/start.sh",
     "dfx:pull": "dfx deps pull",

--- a/scripts/AUTOBUILD.sh
+++ b/scripts/AUTOBUILD.sh
@@ -122,10 +122,8 @@ print_help() { # Help message function
     echo "  deploy       Build & Deploy the application"
     echo "  --help       Display this help message"
     echo
-    echo "Options for 'clean'"
-    echo "  clean [github username]     Username of the repository developer"
     echo "Options for 'start':"
-    echo "  bitcoin                     Enable bitcoin support in DFX"
+    echo "  bitcoin      Enable bitcoin support in DFX"
     echo
     echo "Example:"
     echo "  $0 deploy         # Deploy the application"
@@ -141,14 +139,8 @@ CWD=$PWD
 if [ "$1" = "clean" ]
 then
 	rm -rf * .* 
-    if [[ ! -z $2 ]]
-    then
-        echo git clone https://github.com/$2/B3Wallet.git .
-        echo git clone https://github.com/$2/b3_utils.git ./backend/lib/b3_utils
-    else
-        echo git clone https://github.com/B3Pay/B3Wallet.git .
-        echo git clone https://github.com/B3Pay/b3_utils.git ./backend/lib/b3_utils
-    fi
+	git clone https://github.com/B3Pay/B3Wallet.git .
+	git clone https://github.com/B3Pay/b3_utils.git ./backend/lib/b3_utils
   exit
 fi
 


### PR DESCRIPTION
Reverts B3Pay/B3Wallet#41

@sadernalwis Why didn't use `"autobuild": "bash ./scripts/AUTOBUILD.sh"` user can run `yarn autobuild --help` easier, and also `yarn autobuild deploy`?